### PR TITLE
Fix issue #93 - use of deprecated hass.helpers.aiohttp_client

### DIFF
--- a/custom_components/daikin_altherma/__init__.py
+++ b/custom_components/daikin_altherma/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import Throttle
 from pyaltherma.comm import DaikinWSConnection
 from pyaltherma.controllers import AlthermaController
@@ -26,7 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def setup_api_instance(hass, host):
-    session = hass.helpers.aiohttp_client.async_get_clientsession()
+    session = async_get_clientsession(hass)
     conn = DaikinWSConnection(session, host)
     device = AlthermaController(conn)
     await device.discover_units()


### PR DESCRIPTION
Apply fix described at https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers/